### PR TITLE
Handle rogue shift keys

### DIFF
--- a/barcode_scanner_block.py
+++ b/barcode_scanner_block.py
@@ -80,9 +80,17 @@ class BarcodeScanner(GeneratorBlock):
         self.logger.debug('buffer: {}'.format([hexlify(b) for b in buffer]))
         shift = False
         output = ''
+        zeroes = 0
         for b in buffer:
             if b == b'\x00':
+                zeroes += 1
+                # If we've read more than 2 straight 0s then reset our shift
+                # Sometimes rogue shift keys seem to come through when they
+                # aren't actually shifting anything
+                if zeroes > 2:
+                    shift = False
                 continue
+            zeroes = 0
             if b == b'\x02':  # shift the next character
                 shift = True
                 continue


### PR DESCRIPTION
Sometimes we would see a shift (`0x02`) without any key that it was shifting. This would incorrectly shift the next non-shifted character. This PR says that if we see 3 zeroes in a row to reset any shift we knew about.